### PR TITLE
feat: change all green colors to yellow in frontend

### DIFF
--- a/frontend/COLOR_PALETTE.md
+++ b/frontend/COLOR_PALETTE.md
@@ -41,8 +41,8 @@ This document outlines the color palette used in the Growth application, with a 
 ## Semantic Colors
 
 ### Success
-- **Primary**: `text-green-600` (#16a34a)
-- **Background**: `bg-green-100` (#dcfce7)
+- **Primary**: `text-yellow-600` (#d97706)
+- **Background**: `bg-yellow-100` (#fef3c7)
 - **Usage**: Success messages, completed tasks
 
 ### Error

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -64,7 +64,7 @@ export default function DashboardPage() {
                 </div>
                 <div className="flex justify-between">
                   <span className="text-gray-800">Active Today</span>
-                  <span className="font-semibold text-green-600">0</span>
+                  <span className="font-semibold text-yellow-600">0</span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-gray-800">Completed Today</span>

--- a/frontend/src/components/molecules/RoutineStats/RoutineStats.tsx
+++ b/frontend/src/components/molecules/RoutineStats/RoutineStats.tsx
@@ -22,7 +22,7 @@ const RoutineStats: React.FC<RoutineStatsProps> = ({
         </div>
         <div className="flex justify-between">
           <span className="text-gray-800">Completed Today</span>
-          <span className="font-semibold text-green-600">{completedToday}</span>
+          <span className="font-semibold text-yellow-600">{completedToday}</span>
         </div>
         <div className="flex justify-between">
           <span className="text-gray-800">Days Active</span>

--- a/frontend/src/components/organisms/TaskList/TaskList.tsx
+++ b/frontend/src/components/organisms/TaskList/TaskList.tsx
@@ -77,7 +77,7 @@ const TaskList: React.FC<TaskListProps> = ({
                   <p className="text-xs text-gray-700 font-medium">Goals:</p>
                   <div className="flex flex-wrap gap-1 mt-1">
                     {task.goals.map((goal, index) => (
-                      <span key={index} className="text-xs bg-green-100 text-green-800 px-2 py-1 rounded">
+                      <span key={index} className="text-xs bg-yellow-100 text-yellow-800 px-2 py-1 rounded">
                         {goal.target.name}: {goal.target.value}
                       </span>
                     ))}

--- a/frontendv2/src/components/molecules/RoutineStats/RoutineStats.tsx
+++ b/frontendv2/src/components/molecules/RoutineStats/RoutineStats.tsx
@@ -22,7 +22,7 @@ const RoutineStats: React.FC<RoutineStatsProps> = ({
         </div>
         <div className="flex justify-between">
           <span className="text-gray-800">Completed Today</span>
-          <span className="font-semibold text-green-600">{completedToday}</span>
+          <span className="font-semibold text-yellow-600">{completedToday}</span>
         </div>
         <div className="flex justify-between">
           <span className="text-gray-800">Days Active</span>

--- a/frontendv2/src/components/organisms/TaskList/TaskList.tsx
+++ b/frontendv2/src/components/organisms/TaskList/TaskList.tsx
@@ -77,7 +77,7 @@ const TaskList: React.FC<TaskListProps> = ({
                   <p className="text-xs text-gray-700 font-medium">Goals:</p>
                   <div className="flex flex-wrap gap-1 mt-1">
                     {task.goals.map((goal, index) => (
-                      <span key={index} className="text-xs bg-green-100 text-green-800 px-2 py-1 rounded">
+                      <span key={index} className="text-xs bg-yellow-100 text-yellow-800 px-2 py-1 rounded">
                         {goal.target.name}: {goal.target.value}
                       </span>
                     ))}


### PR DESCRIPTION
Fixes #1

## Summary
Changed all green colors to yellow in the frontend as requested.

## Changes
- Updated all green Tailwind classes to yellow equivalents
- Updated COLOR_PALETTE.md documentation
- Applied changes consistently across both frontend directories

## Files Modified
- Dashboard page
- TaskList component
- RoutineStats component
- Color palette documentation

Generated with [Claude Code](https://claude.ai/code)